### PR TITLE
sdk: add menu item postfix arg (closes #36)

### DIFF
--- a/sdk/lib/lilka/src/lilka/menu.cpp
+++ b/sdk/lib/lilka/src/lilka/menu.cpp
@@ -23,11 +23,12 @@ Menu::~Menu() {
     delete iconCanvas;
 }
 
-void Menu::addItem(String title, const menu_icon_t* icon, uint16_t color) {
+void Menu::addItem(String title, const menu_icon_t* icon, uint16_t color, String postfix) {
     items.push_back({
         .title = title,
         .icon = icon,
         .color = color,
+        .postfix = postfix,
     });
 }
 
@@ -146,6 +147,18 @@ void Menu::draw(Arduino_GFX* canvas) {
         }
         // gfx->print(i == cursor ? "> " : "  ");
         canvas->println(items[i].title);
+
+        if (items[i].postfix.length()) {
+            // Calculate postfix width
+            int16_t x1, y1;
+            uint16_t w, h;
+            canvas->getTextBounds(items[i].postfix, 0, 0, &x1, &y1, &w, &h);
+            (void)x1;
+            (void)y1;
+            (void)h;
+            canvas->setCursor(canvas->width() - w - 8, 80 + screenI * 24);
+            canvas->println(items[i].postfix);
+        }
     }
 
     // Draw scrollbar

--- a/sdk/lib/lilka/src/lilka/ui.h
+++ b/sdk/lib/lilka/src/lilka/ui.h
@@ -15,6 +15,7 @@ typedef struct {
     String title;
     const menu_icon_t* icon;
     uint16_t color;
+    String postfix;
 } MenuItem;
 
 /// Клас для відображення меню.
@@ -55,7 +56,8 @@ public:
     /// @param title Заголовок пункту.
     /// @param icon Іконка пункту (масив з ``uint16_t`` розміром 576 елементів, який представляє 24x24px зображення). За замовчуванням ``0`` (відсутня іконка).
     /// @param color Колір пункту. За замовчуванням ``0`` (стандартний колір).
-    void addItem(String title, const menu_icon_t* icon = 0, uint16_t color = 0);
+    /// @param postfix Текст, який додається після заголовка пункту і вирівнюється до правого краю меню.
+    void addItem(String title, const menu_icon_t* icon = 0, uint16_t color = 0, String postfix = "");
     /// Встановити курсор на пункт меню.
     /// @param cursor Індекс пункту меню.
     void setCursor(int16_t cursor);


### PR DESCRIPTION
Додав четвертим аргументом з двох причин:
- Щоб не рефакторити всі місця, де викликається `Menu::addItem`
- `postfix` використовується рідше, ніж колір чи іконка, тому є сенс вказувати його останнім агрументом