### PR TITLE
A bit of cleaning(keira->icon.h)

### DIFF
--- a/firmware/keira/src/apps/icons/icon.h
+++ b/firmware/keira/src/apps/icons/icon.h
@@ -1,8 +1,0 @@
-#ifndef ICON_H
-#define ICON_H
-
-#include <stdint.h>
-
-typedef uint16_t menu_icon_t[576];
-
-#endif // ICON_H


### PR DESCRIPTION
There's no reasons to keep it, cuz it's menu_icon_t allready defined in sdk -> ui.h
file doesn't have any other code