### PR TITLE
Yboichuk/sdk/nvs config

### DIFF
--- a/sdk/lib/lilka/src/lilka/nvs_config.cpp
+++ b/sdk/lib/lilka/src/lilka/nvs_config.cpp
@@ -1,0 +1,30 @@
+#include "nvs_config.h"
+#include <Preferences.h>
+
+namespace lilka{
+
+    Preferences preferences;
+
+    void saveConfiguration(const Configuration& config) {
+        preferences.begin("config", false); // "config" is the namespace, false indicates read-only
+        preferences.putString("config_data", String(reinterpret_cast<const char*>(&config), sizeof(Configuration)));
+        preferences.end();
+    }
+
+    void loadConfiguration(Configuration& config) {
+        preferences.begin("config", true); // "config" is the namespace, true indicates read-only
+        String data = preferences.getString("config_data", "");
+        preferences.end();
+
+        if (data.length() == sizeof(Configuration)) {
+            memcpy(&config, data.c_str(), sizeof(Configuration));
+        }
+        setDefaultConfiguration();
+    }
+
+    void setDefaultConfiguration() {
+        Configuration defaultConfig;
+        saveConfiguration(defaultConfig);
+    }
+    
+}

--- a/sdk/lib/lilka/src/lilka/nvs_config.cpp
+++ b/sdk/lib/lilka/src/lilka/nvs_config.cpp
@@ -1,30 +1,30 @@
 #include "nvs_config.h"
 #include <Preferences.h>
 
-namespace lilka{
+namespace lilka {
 
-    Preferences preferences;
+Preferences preferences;
 
-    void saveConfiguration(const Configuration& config) {
-        preferences.begin("config", false); // "config" is the namespace, false indicates read-only
-        preferences.putString("config_data", String(reinterpret_cast<const char*>(&config), sizeof(Configuration)));
-        preferences.end();
-    }
-
-    void loadConfiguration(Configuration& config) {
-        preferences.begin("config", true); // "config" is the namespace, true indicates read-only
-        String data = preferences.getString("config_data", "");
-        preferences.end();
-
-        if (data.length() == sizeof(Configuration)) {
-            memcpy(&config, data.c_str(), sizeof(Configuration));
-        }
-        setDefaultConfiguration();
-    }
-
-    void setDefaultConfiguration() {
-        Configuration defaultConfig;
-        saveConfiguration(defaultConfig);
-    }
-    
+void saveConfiguration(const Configuration& config) {
+    preferences.begin("config", false); // "config" is the namespace, false indicates read-only
+    preferences.putString("config_data", String(reinterpret_cast<const char*>(&config), sizeof(Configuration)));
+    preferences.end();
 }
+
+void loadConfiguration(Configuration& config) {
+    preferences.begin("config", true); // "config" is the namespace, true indicates read-only
+    String data = preferences.getString("config_data", "");
+    preferences.end();
+
+    if (data.length() == sizeof(Configuration)) {
+        memcpy(&config, data.c_str(), sizeof(Configuration));
+    }
+    setDefaultConfiguration();
+}
+
+void setDefaultConfiguration() {
+    Configuration defaultConfig;
+    saveConfiguration(defaultConfig);
+}
+
+} // namespace lilka

--- a/sdk/lib/lilka/src/lilka/nvs_config.h
+++ b/sdk/lib/lilka/src/lilka/nvs_config.h
@@ -3,15 +3,15 @@
 
 #include <Arduino.h>
 
-namespace lilka{
-    
-    // Define your configuration struct
-    struct Configuration {
-        String language = "en";
-    };
+namespace lilka {
 
-    void saveConfiguration(const Configuration& config);
-    void loadConfiguration(Configuration& config);
-    void setDefaultConfiguration();
-}
+// Define your configuration struct
+struct Configuration {
+    String language = "en";
+};
+
+void saveConfiguration(const Configuration& config);
+void loadConfiguration(Configuration& config);
+void setDefaultConfiguration();
+} // namespace lilka
 #endif // CONFIGURATION_H

--- a/sdk/lib/lilka/src/lilka/nvs_config.h
+++ b/sdk/lib/lilka/src/lilka/nvs_config.h
@@ -1,0 +1,17 @@
+#ifndef CONFIGURATION_H
+#define CONFIGURATION_H
+
+#include <Arduino.h>
+
+namespace lilka{
+    
+    // Define your configuration struct
+    struct Configuration {
+        String language = "en";
+    };
+
+    void saveConfiguration(const Configuration& config);
+    void loadConfiguration(Configuration& config);
+    void setDefaultConfiguration();
+}
+#endif // CONFIGURATION_H


### PR DESCRIPTION
Add support for save and read config from nvs for keira OS

Now setting have only one field, named as "language", but here we can story any what for save from boot to boot

`  lilka::Configuration config;

  // Load the configuration
  lilka::loadConfiguration(config);

  // Print the language from the configuration
  Serial.print("Current language: ");
  Serial.println(config.language);`