### PR TITLE
Temporary fix of alert draw after long operation, probably better one doesn't exist

### DIFF
--- a/firmware/keira/src/apps/launcher.cpp
+++ b/firmware/keira/src/apps/launcher.cpp
@@ -452,6 +452,11 @@ void LauncherApp::alert(String title, String message) {
     lilka::Alert alert(title, message);
     alert.draw(canvas);
     queueDraw();
+    // We need to ensure that backcanvas and canvas both have rendered
+    // our alert, or in case of long operation(file size detection),
+    // there's probability that nothing would be shown
+    alert.draw(canvas);
+    queueDraw();
     while (!alert.isFinished()) {
         alert.update();
         taskYIELD();


### PR DESCRIPTION
After time consuming operations, in my case(file size detection), lilka::alert could be not drawn.

Highly likely reason is that lilka:alert should be drawn only once, and statusbar which renders each second, could skip a frame with alert, and repeat redrawing this one, so alert wouldn't be displayed at all.

As a temporary fix we just draw alert twice, and it works