### PR TITLE
Wrong windspeed units

### DIFF
--- a/firmware/keira/src/apps/weather/weather.cpp
+++ b/firmware/keira/src/apps/weather/weather.cpp
@@ -242,7 +242,7 @@ void WeatherApp::run() {
                 canvas->print(String(temp, 1) + " °C");
                 canvas->setFont(FONT_10x20);
                 canvas->setCursor(canvas->width() / 2, canvas->height() / 2 + 20 / 2 + 10);
-                canvas->print(String(wind, 1) + " м/с");
+                canvas->print(String(wind, 1) + " км/год");
                 queueDraw();
             }
         } else {


### PR DESCRIPTION
Якщо відкрити URL в браузері - то у відповіді видно, що одиниці - km/h. І з прогнозом з інших джерел співпадає. https://api.open-meteo.com/v1/forecast?latitude=49.8397&longitude=24.0297&current=temperature_2m,wind_speed_10m,weather_code