### PR TITLE
Add some delay in all ui updates

### DIFF
--- a/sdk/lib/lilka/src/lilka/alert.cpp
+++ b/sdk/lib/lilka/src/lilka/alert.cpp
@@ -29,6 +29,7 @@ void Alert::update() {
         button = *it;
         done = true;
     }
+    vTaskDelay(LILKA_UI_UPDATE_DELAY_MS / portTICK_PERIOD_MS);
 }
 
 void Alert::draw(Arduino_GFX* canvas) {

--- a/sdk/lib/lilka/src/lilka/inputdialog.cpp
+++ b/sdk/lib/lilka/src/lilka/inputdialog.cpp
@@ -117,6 +117,7 @@ void InputDialog::update() {
             cx = 0;
         }
     }
+    vTaskDelay(LILKA_UI_UPDATE_DELAY_MS / portTICK_PERIOD_MS);
 }
 
 void InputDialog::draw(Arduino_GFX* canvas) {

--- a/sdk/lib/lilka/src/lilka/menu.cpp
+++ b/sdk/lib/lilka/src/lilka/menu.cpp
@@ -85,6 +85,7 @@ void Menu::update() {
             done = true;
         }
     }
+    vTaskDelay(LILKA_UI_UPDATE_DELAY_MS / portTICK_PERIOD_MS);
 }
 
 // Scroll marquee back and forth based on time, pausing at start and end

--- a/sdk/lib/lilka/src/lilka/ui.h
+++ b/sdk/lib/lilka/src/lilka/ui.h
@@ -7,6 +7,8 @@
 #include "display.h"
 #include "controller.h"
 
+#define LILKA_UI_UPDATE_DELAY_MS 10
+
 constexpr uint16_t menu_icon_width = 24;
 constexpr uint16_t menu_icon_height = 24;
 typedef uint16_t const menu_icon_t[menu_icon_width * menu_icon_height]; // 24x24px icon (576*2 bytes)


### PR DESCRIPTION
This won't affect NES frame rendering speed and other tasks whose not use sdk/ui, but theoretically should improve work of all background services.
